### PR TITLE
Add a reporter that posts comments as a single PR review

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ access token and use that for the `--github-password` above.
 
 ### Full Usage Info
 ```
-usage: imhotep [-h] [--config-file CONFIG_FILE] --repo_name REPO_NAME [--commit COMMIT] [--origin-commit ORIGIN_COMMIT] [--filenames FILENAMES [FILENAMES ...]] [--debug] [--github-username GITHUB_USERNAME] [--github-password GITHUB_PASSWORD] [--no-post] [--authenticated] [--pr-number PR_NUMBER] [--cache-directory CACHE_DIRECTORY] [--linter LINTER [LINTER ...]] [--shallow]
-               [--github-domain GITHUB_DOMAIN] [--report-file-violations] [--dir-override DIR_OVERRIDE]
+usage: imhotep [-h] [--config-file CONFIG_FILE] --repo_name REPO_NAME [--commit COMMIT] [--origin-commit ORIGIN_COMMIT] [--filenames FILENAMES [FILENAMES ...]] [--debug] [--github-username GITHUB_USERNAME] [--github-password GITHUB_PASSWORD] [--no-post] [--authenticated] [--pr-number PR_NUMBER] [--cache-directory CACHE_DIRECTORY] [--linter LINTER [LINTER ...]] [--shallow] [--github-domain GITHUB_DOMAIN] [--report-file-violations] [--dir-override DIR_OVERRIDE]
+               [--submit-comments-separately]
 
 Posts static analysis results to github.
 
@@ -119,6 +119,8 @@ options:
                         Report file-level violations, i.e. those not on individual lines
   --dir-override DIR_OVERRIDE
                         Override the full path to the local repository.
+  --submit-comments-separately
+                        When reviewing a PR, rather than posting a single PR review, post separate comments
 ```
 
 Note: if you get a error where the plugin cannot find `imhotep.tools`, make
@@ -184,6 +186,9 @@ not spacing and misspelling issues.
 # Release Notes
 
 ### 3.0.0
+Features:
+- When reviewing a PR, post comments as a single review by default. If you want the original behavior, specify `--submit-comments-separately`.
+
 Backwards incompatible change:
 - Dropped support for Python < 3.9 and pypy.
 

--- a/imhotep/app.py
+++ b/imhotep/app.py
@@ -223,7 +223,7 @@ class Imhotep:
                 log.info("%d violations.", error_count)
                 if hasattr(reporter, "submit_review"):
                     log.debug("Submitting review.")
-                    reporter.submit_review()
+                    reporter.submit_review()  # type: ignore
         finally:
             self.manager.cleanup()
 

--- a/imhotep/app.py
+++ b/imhotep/app.py
@@ -86,7 +86,7 @@ class Imhotep:
         github_domain: Optional[str] = None,
         report_file_violations: bool = False,
         dir_override: Optional[str] = None,
-        should_submit_comments_separately: bool = false,
+        should_submit_comments_separately: bool = False,
         **kwargs,
     ) -> None:
         # TODO(justinabrahms): kwargs exist until we handle cli params better

--- a/imhotep/app.py
+++ b/imhotep/app.py
@@ -221,9 +221,9 @@ class Imhotep:
                         " continue.".format(error_count=error_count)
                     )
                 log.info("%d violations.", error_count)
-                if hasattr(reporter, "submit_review"):
-                    log.debug("Submitting review.")
-                    reporter.submit_review()  # type: ignore
+            if hasattr(reporter, "submit_review"):
+                log.debug("Submitting review.")
+                reporter.submit_review()  # type: ignore
         finally:
             self.manager.cleanup()
 

--- a/imhotep/app_test.py
+++ b/imhotep/app_test.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from unittest import mock
 
 from imhotep.main import load_config
-from imhotep.testing_utils import Requester, fixture_path
+from imhotep.testing_utils import fixture_path
 
 from .app import (
     Imhotep,
@@ -18,7 +18,7 @@ from .app import (
 )
 from .diff_parser import Entry
 from .repomanagers import RepoManager
-from .reporters.github import CommitReporter, PRReporter
+from .reporters.github import CommitReporter, PRReporter, PRReviewReporter
 from .reporters.printing import PrintingReporter
 from .repositories import Repository, ToolsNotFound
 from .tools import Tool
@@ -109,15 +109,28 @@ def test_reporter__printing():
     assert type(i.get_reporter()) == PrintingReporter
 
 
-def test_reporter__pr():
+def test_reporter__pr_via_comments():
     i = Imhotep(
         pr_number=1,
         repo_manager=RepoManager(),
         repo_name="repo_name",
         requester=mock.Mock(),
         github_domain="github.com",
+        should_submit_comments_separately=True,
     )
     assert type(i.get_reporter()) == PRReporter
+
+
+def test_reporter__pr_via_a_review():
+    i = Imhotep(
+        pr_number=1,
+        repo_manager=RepoManager(),
+        repo_name="repo_name",
+        requester=mock.Mock(),
+        github_domain="github.com",
+        should_submit_comments_separately=False,
+    )
+    assert type(i.get_reporter()) == PRReviewReporter
 
 
 def test_reporter__commit():

--- a/imhotep/reporters/github.py
+++ b/imhotep/reporters/github.py
@@ -65,7 +65,7 @@ class GitHubReporter(Reporter):
         file_name: str,
         position: int,
         message: List[str],
-    ) -> Optional[Dict[str, Union[str, int]]]:
+    ) -> Optional[Dict[str, object]]:
         """
         Wraps a message (which is a string) into GitHub-understandable comment (which is a JSON object).
         It checks if there's already an identical comment on the PR. If there is, `None` is returned.
@@ -116,6 +116,7 @@ class PRReporter(GitHubReporter):
     Comments on a PR by posting separate comments, rather than a review on the PR.
     See https://docs.github.com/en/rest/reference/pulls#create-a-review-comment-for-a-pull-request.
     """
+
     def __init__(
         self, requester: BasicAuthRequester, domain: str, repo_name: str, pr_number: str
     ) -> None:
@@ -171,7 +172,7 @@ class PRReviewReporter(PRReporter):
         self, requester: BasicAuthRequester, domain: str, repo_name: str, pr_number: str
     ) -> None:
         super().__init__(requester, domain, repo_name, pr_number)
-        self.comments: List[Dict[str, Union[str, int]]] = list()
+        self.comments: List[Dict[str, object]] = list()
 
     def report_line(
         self,
@@ -186,6 +187,7 @@ class PRReviewReporter(PRReporter):
         if payload is None:
             return None
         self.comments.append(payload)
+        return None
 
     def submit_review(self) -> Optional[Response]:
         """
@@ -197,7 +199,7 @@ class PRReviewReporter(PRReporter):
             self.pr_number,
         )
         if len(self.comments) == 0:
-            return
+            return None
         payload = {
             "body": "Imhotep detected {} potential problems with this PR.".format(
                 len(self.comments)

--- a/imhotep/reporters/github.py
+++ b/imhotep/reporters/github.py
@@ -79,7 +79,6 @@ class CommitReporter(GitHubReporter):
         self.requester.post(report_url, payload)
 
 
-
 class PRReporter(GitHubReporter):
     def __init__(
         self, requester: BasicAuthRequester, domain: str, repo_name: str, pr_number: str
@@ -99,11 +98,7 @@ class PRReporter(GitHubReporter):
         position: int,
         message: List[str],
     ) -> Optional[Response]:
-        payload = self.get_payload(
-            commit,
-            file_name,
-            position,
-            message)
+        payload = self.get_payload(commit, file_name, position, message)
         if payload is None:
             return None
         log.debug("PR Request: %s", self.pr_comments_url)
@@ -127,11 +122,9 @@ class PRReporter(GitHubReporter):
             log.error("Error posting comment to github. %s", result.json())
         return result
 
-    def get_payload(self,
-        commit: str,
-        file_name: str,
-        position: int,
-        message: List[str]) -> Optional[Dict[str, Union[str, int]]]:
+    def get_payload(
+        self, commit: str, file_name: str, position: int, message: List[str]
+    ) -> Optional[Dict[str, Union[str, int]]]:
         """
         Wraps a message (which is a string) into GitHub-understandable comment (which is a JSON object).
         It checks if there's already an identical comment on the PR. If there is, `None` is returned.
@@ -139,7 +132,9 @@ class PRReporter(GitHubReporter):
         existing_comments = self.get_comments(self.pr_comments_url)
         if isinstance(message, str):
             message = [message]
-        message = self.clean_already_reported(existing_comments, file_name, position, message)
+        message = self.clean_already_reported(
+            existing_comments, file_name, position, message
+        )
         if not message:
             log.debug("Message already reported")
             return None

--- a/imhotep/reporters/github.py
+++ b/imhotep/reporters/github.py
@@ -67,12 +67,12 @@ class CommitReporter(GitHubReporter):
         )
         comments = self.get_comments(report_url)
         message = self.clean_already_reported(comments, file_name, position, message)
+        # See https://docs.github.com/en/rest/reference/commits#create-a-commit-comment--parameters.
         payload = {
             "body": self.convert_message_to_string(message),
-            "sha": commit,
+            "commit_sha": commit,
             "path": file_name,
             "position": position,
-            "line": None,
         }
         log.debug("Commit Request: %s", report_url)
         log.debug("Commit Payload: %s", payload)

--- a/imhotep/reporters/github.py
+++ b/imhotep/reporters/github.py
@@ -105,7 +105,10 @@ class CommitReporter(GitHubReporter):
             return None
         log.debug("Commit Request: %s", report_url)
         log.debug("Commit Payload: %s", payload)
-        self.requester.post(report_url, payload)
+        result = self.requester.post(report_url, payload)
+        if result.status_code >= 400:
+            log.error("Error posting line to github. %s", result.json())
+        return result
 
 
 class PRReporter(GitHubReporter):

--- a/imhotep/reporters/github.py
+++ b/imhotep/reporters/github.py
@@ -98,13 +98,11 @@ class CommitReporter(GitHubReporter):
         )
         comments = self.get_comments(report_url)
         message = self.clean_already_reported(comments, file_name, position, message)
-        # See https://docs.github.com/en/rest/reference/commits#create-a-commit-comment--parameters.
-        payload = {
-            "body": self.convert_message_to_string(message),
-            "commit_sha": commit,
-            "path": file_name,
-            "position": position,
-        }
+        payload = self.get_payload(
+            report_url, commit, "commit_sha", file_name, position, message
+        )
+        if payload is None:
+            return None
         log.debug("Commit Request: %s", report_url)
         log.debug("Commit Payload: %s", payload)
         self.requester.post(report_url, payload)

--- a/imhotep/reporters/printing.py
+++ b/imhotep/reporters/printing.py
@@ -6,7 +6,7 @@ log = logging.getLogger(__name__)
 
 
 class PrintingReporter(Reporter):
-    def report_line(self, commit, file_name, line_number, position, message):
+    def report_line(self, commit, file_name, position, message):
         print(
             "Would have posted the following: \n"
             "commit: %(commit)s\n"

--- a/imhotep/reporters/reporters_test.py
+++ b/imhotep/reporters/reporters_test.py
@@ -1,6 +1,11 @@
 from unittest import mock
 
-from imhotep.reporters.github import CommitReporter, GitHubReporter, PRReporter
+from imhotep.reporters.github import (
+    CommitReporter,
+    GitHubReporter,
+    PRReporter,
+    PRReviewReporter,
+)
 from imhotep.reporters.printing import PrintingReporter
 from imhotep.testing_utils import Requester
 
@@ -22,6 +27,18 @@ def test_pr_url():
         requester.url
         == "https://api.github.com/repos/justinabrahms/imhotep/pulls/10/comments"
     )
+
+
+def test_pr_review_reporter_should_add_comments():
+    requester = Requester("")
+    pr = PRReviewReporter(requester, "github.com", "justinabrahms/imhotep", 10)
+    pr.report_line(commit="sha", file_name="script.py", position=0, message="lorem")
+    assert pr.comments == [{"body": "* lorem\n", "path": "script.py", "position": 0}]
+    pr.report_line(commit="sha", file_name="script.py", position=1, message="ipsum")
+    assert pr.comments == [
+        {"body": "* lorem\n", "path": "script.py", "position": 0},
+        {"body": "* ipsum\n", "path": "script.py", "position": 1},
+    ]
 
 
 def test_pr_already_reported():

--- a/imhotep/reporters/reporters_test.py
+++ b/imhotep/reporters/reporters_test.py
@@ -30,7 +30,7 @@ def test_pr_url():
 
 
 def test_pr_review_reporter_should_add_comments():
-    requester = Requester("")
+    requester = mock.MagicMock()
     pr = PRReviewReporter(requester, "github.com", "justinabrahms/imhotep", 10)
     pr.report_line(commit="sha", file_name="script.py", position=0, message="lorem")
     assert pr.comments == [{"body": "* lorem\n", "path": "script.py", "position": 0}]
@@ -39,6 +39,7 @@ def test_pr_review_reporter_should_add_comments():
         {"body": "* lorem\n", "path": "script.py", "position": 0},
         {"body": "* ipsum\n", "path": "script.py", "position": 1},
     ]
+    assert not requester.post.called
 
 
 def test_pr_review_reporter_should_post_review():

--- a/imhotep/reporters/reporters_test.py
+++ b/imhotep/reporters/reporters_test.py
@@ -41,6 +41,18 @@ def test_pr_review_reporter_should_add_comments():
     ]
 
 
+def test_pr_review_reporter_should_post_review():
+    requester = mock.MagicMock()
+    requester.username = "magicmock"
+    requester.post.return_value.status_code = 200
+    pr = PRReviewReporter(requester, "api.github.com", "justinabrahms/imhotep", 10)
+    pr.comments = [
+        {"body": "* lorem\n", "path": "script.py", "position": 0},
+    ]
+    pr.submit_review()
+    assert requester.post.called
+
+
 def test_pr_already_reported():
     requester = mock.MagicMock()
     requester.username = "magicmock"

--- a/imhotep/reporters/reporters_test.py
+++ b/imhotep/reporters/reporters_test.py
@@ -124,7 +124,6 @@ def test_printing_reporter_report_line():
     PrintingReporter().report_line(
         commit="commit",
         file_name="file.py",
-        line_number=123,
         position=1,
         message="message",
     )


### PR DESCRIPTION
This new reporter, `PRReviewReporter`, is helpful to reduce noise for the PR watchers. This is especially important if you're reviewing a huge PR, where a lot of comments can happen.

By grouping comments into one review, we can also reduce the number of POST reports we fire at GitHub, which avoids throttling and is simply more efficient.

Tested against my public repo:

![Screen Shot 2022-04-17 at 00 48 01](https://user-images.githubusercontent.com/594058/163705592-a9f8dcba-4c05-4433-b6af-1ca20939ab82.png)

